### PR TITLE
allow administrator to access manager routes

### DIFF
--- a/src/config/permissions/index.json
+++ b/src/config/permissions/index.json
@@ -1,7 +1,7 @@
 {
   "administrator": {
     "edit profile": 1,
-    "assign requesters to manager": 0,
+    "assign requesters to manager": 1,
     "create travel requests": 1,
     "view travel requests": 1,
     "edit travel requests": 1,

--- a/src/helper/isManager.js
+++ b/src/helper/isManager.js
@@ -8,9 +8,8 @@ const isManager = async (req, res, next) => {
   const token = bearerToken.split(' ')[1];
   const decoded = await verifyToken(token);
   const roles = await findRoles(decoded.role);
-  if (roles.name !== 'manager') throw new UnauthorizedError('Access denied');
-  if (roles.name === 'manager') return next();
+  if (roles.name !== 'manager' && roles.name !== 'administrator') throw new UnauthorizedError('Access denied');
+  if (roles.name === 'manager' || roles.name === 'administrator') return next();
 };
-// user.user_role_id
 
 export default isManager;

--- a/tests/adminRoutes.test.js
+++ b/tests/adminRoutes.test.js
@@ -13,9 +13,7 @@ let User = '';
 describe('Testing the route of retrieving all roles', () => {
   it('should return all roles for success', async () => {
     User = await request(app).post('/api/v1/user/login').send(adminCredentials);
-    console.log(User.body.data);
     const res = await request(app).get('/api/v1/admin/roles').set('Authorization', `Bearer ${User.body.data}`);
-
     expect(res.type).to.equal('application/json');
     expect(res).to.have.status(200);
     expect(res.body).to.have.property('status');

--- a/tests/upatedNotification.test.js
+++ b/tests/upatedNotification.test.js
@@ -12,7 +12,6 @@ describe('/api/v1/user/verified-users-manager', () => {
   });
   it('It should not update notification', async () => {
     const res = await request(app).patch('/api/v1/notification/notifications/d5e63e3b-3a7b-4e23-9855-8250e93124aa').set('Authorization', `Bearer ${testToken}`);
-    console.log(res.body);
     expect(res).to.have.status(404);
     expect(res.type).to.equal('application/json');
   });


### PR DESCRIPTION
# Description

I created this PR in order to allow the administrator to access the manager's routes to assign line managers and also get the verified users route

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How should this be manually tested or reproduced?

- Clone this repo
- Checkout to `fix-managers-routes`
- Run the command `npm i`
- Run the command `npm run test` to run tests locally 
- If you push new changes, the test shall run on travis

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

# Screenshots (if applicable)